### PR TITLE
ci: update base href

### DIFF
--- a/.github/workflows/scully-publish-to-gh-pages.yml
+++ b/.github/workflows/scully-publish-to-gh-pages.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           deploy-branch: gh-pages
-          build-args: --base-href /website-bem-da-terra/
+          build-args: --base-href /


### PR DESCRIPTION
now that the site already
have its custom domain
the workflow doesn't need
to point base href to the
ghpages repository name